### PR TITLE
Fix: ThirdWeb runtime errors

### DIFF
--- a/weirdle/next.config.js
+++ b/weirdle/next.config.js
@@ -1,1 +1,5 @@
-module.exports = {};
+module.exports = {
+  optimization: {
+    runtimeChunk: "single",
+  },
+};


### PR DESCRIPTION
using `optimization.runtimeChunk: "single"`. This makes sure we only have a single runtime (with module cache) and modules are not instantiated twice.